### PR TITLE
Rekey deferred files for aggregation

### DIFF
--- a/js_defer.module
+++ b/js_defer.module
@@ -62,8 +62,15 @@ function js_defer_js_alter(&$javascript) {
       }
     }
     if (variable_get('preprocess_js') && !empty($aggregated_files)) {
-      // Build the aggregated file and add it to the deferred list at the end.
-      $uri = drupal_build_js_cache($aggregated_files);
+      // Rekey deferred files for aggregation to include alterations of 'data'
+      // @see drupal_add_js()
+      $rekeyed_aggregated_files = array();
+      foreach ($aggregated_files as $item) {
+        $rekeyed_aggregated_files[$item['data']] = $item;
+      }
+      // Build the aggregated file
+      $uri = drupal_build_js_cache($rekeyed_aggregated_files);
+      // Add the aggregated file to the end of the deferred list the end
       $deferred_files[] = file_create_url($uri);
     }
     drupal_add_deferred_js($context, $deferred_files, $deferred_info);


### PR DESCRIPTION
Say you have fancy logic to replace all of your JS files with `min.js` versions.

``` php
foreach ($files as $file)
   $file['data'] = str_replace('.js', '.min.js', file['data']);
```

Your original sources as keys and the modified buried in the array :thumsup:.
However, js_defer won't currently respect that when aggregation is turned on :cry:.

`drupal_build_js_cache()` won't use 'data' for getting contents (it does for hash name though).

```
foreach ($files as $path => $info) {
  if ($info['preprocess']) {
    // Append a ';' and a newline after each JS file to prevent them from running together.
    $contents .= file_get_contents($path) . ";\n";
  }
}
```

How are other popular 'min.js' variants picked up?

`drupal_get_js` knows this quirk and rekeys the array in advance :see_no_evil:

```
$key = 'aggregate_' . $item['group'] . '_' . $item['every_page'] . '_' . $index;
$processed[$key] = '';
$files[$key][$item['data']] = $item;
```
