### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ready. And you want it **fast**.
 
 ## Dependencies
 
-This module depends on two javascript libraries:
+This module depends on the following javascript libraries:
 
   - The [LazyLoad](https://github.com/rgrove/lazyload) library to do the actual
   lazy load of the specified scripts.


### PR DESCRIPTION
small change to how the dependencies are described. It said two but only one is listed so making the sentence not have a number specified solves for the case that you list any number of dependencies.
