### PR TITLE
Fix inline-script 'group' bump.

### DIFF
--- a/js_defer.module
+++ b/js_defer.module
@@ -29,7 +29,7 @@ function js_defer_js_alter(&$javascript) {
   foreach ($info as $context => $deferred_info) {
     $deferred_scripts = empty($deferred_info['scripts']) ? array() : $deferred_info['scripts'];
     foreach ($javascript as $deferred_script_candidate => $script_definition) {
-      if (in_array($deferred_script_candidate, $deferred_scripts)) {
+      if (in_array($deferred_script_candidate, $deferred_scripts, TRUE)) {
         // Put everything at the bottom of the queue when loading scripts.
         $javascript[$deferred_script_candidate]['group'] = JS_DEFERRED;
         // If Drupal serves the file then we add the file to the aggregation.


### PR DESCRIPTION
An inline script may have `0` as it's index which can be found when matching array of strings.

``` php
$deferred_script_candidate = 0;
$deferred_scripts = array('a.js', 'b.js');
$result = in_array($deferred_script_candidate, $deferred_scripts);
var_dump($result);
```
