### PR TITLE
Allow option to only run new behaviors since deferred queue loaded

### DIFF
--- a/js_defer.api.php
+++ b/js_defer.api.php
@@ -16,6 +16,8 @@
  *     * 'timeout': Trigger the queue to load after a timeout.
  *     * FALSE: No fallback.
  *   - timeout: The amount of seconds before the queue is manually started.
+ *   - reattach_all_behaviors: Set to false if you only want to run new
+ *     behaviors after deferred files have been loaded. Defaults to TRUE
  *   - scripts: An array of file names as the keys for the argument in
  *     hook_js_alter
  */
@@ -23,6 +25,7 @@ function hook_js_defer_info() {
   $deferred['js-queue'] = array(
     'fallback' => 'timeout',
     'timeout' => 10,
+    'reattach_all_behaviors': FALSE,
     'scripts' => array(
       'sites/all/modules/module-name/js/javascript-file1.js',
       'sites/all/modules/module-name/js/javascript-file2.js',
@@ -30,6 +33,7 @@ function hook_js_defer_info() {
   );
   $deferred['js-queue-2'] = array(
     'fallback' => FALSE,
+    'reattach_all_behaviors': TRUE,
     'scripts' => array(
       'sites/all/modules/module-name/js/javascript-file3.js',
       'sites/all/modules/module-name/js/javascript-file4.js',

--- a/js_defer.module
+++ b/js_defer.module
@@ -14,8 +14,7 @@ define('JS_DEFERRED', 200);
  * Implements hook_js_alter().
  */
 function js_defer_js_alter(&$javascript) {
-  // First we need to identify the libraries that are messing with the load of:
-  //   - The player for the video detail page.
+  // First we need to identify scripts to be deferred
 
   // All these scripts should not load inside the preprocessed file and should
   // be deferred to load after the player is ready.
@@ -39,7 +38,7 @@ function js_defer_js_alter(&$javascript) {
           $deferred_files[] = $deferred_script_candidate;
         }
         else if ($javascript[$deferred_script_candidate]['type'] === 'file') {
-          // Don't defer this file directly, add it to a aggragated file and
+          // Don't defer this file directly, add it to a aggregated file and
           // then defer that one.
           if (variable_get('preprocess_js', FALSE)) {
             $aggregated_files[$deferred_script_candidate] = $script_definition;
@@ -99,7 +98,7 @@ function js_defer_js_alter(&$javascript) {
  *   Additional settings to be passed to the LazyLoad js settings object.
  *
  * @todo We need to decide when to load the minified version and when the full
- * one (mabe using preprocess_js). To load one or the other we could use library
+ * one (maybe using preprocess_js). To load one or the other we could use library
  * variants registering our libraries with hook_libraries_info() and then
  * calling libraries_load('libname', 'minified').
  */


### PR DESCRIPTION
Added key reattach_all_behaviors to hook_js_defer_info()
Added logic to lazy-load.js to honor the setting, made behavior default to loading all behaviors
Removed unnecessary reference to window in enclosure
Fixed typos in docs
Changed some language specific originating project in comments to be more general
