### PR TITLE
[#16] Use assoc array when defining scripts in PHP

### DIFF
--- a/js/lazy-load-js.js
+++ b/js/lazy-load-js.js
@@ -32,7 +32,9 @@
     var existingBehaviors;
 
     // Ensure we that have scripts to load
-    if (!Drupal.settings.js_defer[queueName] || !Drupal.settings.js_defer[queueName].scripts.length) {
+    if (typeof Drupal.settings.js_defer[queueName] === "undefined" ||
+      typeof Drupal.settings.js_defer[queueName].scripts === "undefined"
+    ) {
       return;
     }
     // Ensure we that have not yet queued these scripts
@@ -43,11 +45,16 @@
     // Make sure this last bit isn't run twice for the same queue
     Drupal.settings.js_defer[queueName].once = true;
 
+    // The scripts come in as an object to ensure there are no duplicates, but
+    // we need them to be an array. The keys of the object properties are
+    // identical to the values, so we can just use Object.keys().
+    var scripts = Object.keys(Drupal.settings.js_defer[queueName].scripts);
+
     // Run only new behaviors added from the queue, or load all, depending on
     // queue's reattach_all_behaviors setting.
     if (Drupal.settings.js_defer[queueName].reattach_all_behaviors === false) {
       existingBehaviors = $.extend(true, {}, Drupal.behaviors);
-      LazyLoad.js(Drupal.settings.js_defer[queueName].scripts, function () {
+      LazyLoad.js(scripts, function () {
         // Execute only new behaviors since we ran the queue
         $.each(Drupal.behaviors, function (index) {
           if (typeof existingBehaviors[index] === 'undefined' && $.isFunction(this.attach)) {
@@ -56,7 +63,7 @@
         });
       });
     } else {
-      LazyLoad.js(Drupal.settings.js_defer[queueName].scripts, function () {
+      LazyLoad.js(scripts, function () {
         Drupal.attachBehaviors(document, Drupal.settings);
       });
     }

--- a/js_defer.module
+++ b/js_defer.module
@@ -131,6 +131,10 @@ function drupal_add_deferred_js(&$javascript, $queue_name, $scripts, $additional
       $ev_settings[] = $script;
     }
   }
+  // Add these scripts as an associative array so that it becomes an object when
+  // converted to JavaScript. This ensures that AJAX requests don't overwrite
+  // existing deferred scripts in Drupal.settings.
+  $settings[$queue_name]['scripts'] = array_combine($ev_settings, $ev_settings);
 
   // If we already have a js_defer setting, then append to it.
   $key = 'js_defer';


### PR DESCRIPTION
If a sequential array is used for declaring the scripts to be deferred
in PHP, that PHP array is converted to a JavaScript array, and then
cannot be properly extended without possibly duplicating and / or
removing existing deferred scripts, in the case of an AJAX request that
extends the Drupal settings.

Using an associative array in PHP will convert to a JavaScript object.
In this commit, we declare the associative array with equivalent keys
and values, which will ensure that all scripts are included, and that no
duplicates are possible. We then use `Object.keys()` to convert that
object into a JavaScript array just before processing with LazyLoad.

Resolves #16.
